### PR TITLE
Simplify types and reduce use of any

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,5 @@
 import { Environment } from "./Environment";
-import { BuiltinToken } from "./tokens";
+import { ParseToken } from "./tokens";
 export * from "./tokens";
 export * from "./transforms";
 export { Environment } from "./Environment";
@@ -8,7 +8,7 @@ export { Environment } from "./Environment";
  * @param expression The input text to parse. Eg: "${NODE_ENV:-${ENV:-prod}}", "My name is $NAME",
  * "And '  quoted' spaces".
  * @returns The parse tree representing the input. */
-export declare const parse: (expression: string) => readonly BuiltinToken[];
+export declare const parse: (expression: string) => readonly ParseToken[];
 /** Replaces environment variables in the input.
  * @param expression The input text. Eg: "${NODE_ENV:-${ENV:-prod}}", "My name is $NAME",
  * "And '  quoted' spaces".

--- a/dist/index.js
+++ b/dist/index.js
@@ -1488,7 +1488,7 @@ const parseEnvValue = (value) => parser_1(value, parseOptions);
  * to true to enable `cross-env` style variable assignment. If true, the tokens are removed from the
  * resulting tree once assigned. */
 function substitute(token, env, inlineAssignment = false) {
-    return transformChildren(token, sub);
+    return sub(token);
     function sub(token) {
         if (token instanceof Variable) {
             const value = env[token.name];

--- a/dist/tokens/QuotedString.d.ts
+++ b/dist/tokens/QuotedString.d.ts
@@ -1,9 +1,10 @@
-import { TransformChildren } from "./infrastructure";
+import { TransformChildren, ITokenTransform } from "./infrastructure";
+import { Token } from ".";
 /** Text quoted with double quotes: ". Variables substitution is performed in these strings and
  * whitespace is preserved, but no other characters like ' have any special meaning. */
 export declare class QuotedString {
-    readonly contents: ReadonlyArray<any> | string;
-    constructor(contents: ReadonlyArray<any> | string);
+    readonly contents: Token | ReadonlyArray<Token>;
+    constructor(contents: Token | ReadonlyArray<Token>);
     toString(): string;
-    [TransformChildren](transformer: (item: any) => any): QuotedString;
+    [TransformChildren](transformer: ITokenTransform): QuotedString;
 }

--- a/dist/tokens/TokenKind.d.ts
+++ b/dist/tokens/TokenKind.d.ts
@@ -1,10 +1,8 @@
 export declare const enum TokenKind {
-    List = 0,
-    Whitespace = 1,
-    Variable = 2,
-    VariableAssignment = 3,
-    SubstitutedVariable = 4,
-    Text = 5,
-    QuotedText = 6,
-    LiteralText = 7
+    Variable = 0,
+    VariableAssignment = 1,
+    Word = 2,
+    QuotedString = 3,
+    VerbatimString = 4,
+    Whitespace = 5
 }

--- a/dist/tokens/Variable.d.ts
+++ b/dist/tokens/Variable.d.ts
@@ -1,11 +1,12 @@
-import { TransformChildren } from "./infrastructure";
+import { TransformChildren, ITokenTransform } from "./infrastructure";
+import { Token } from ".";
 /** A variable reference like $VAR, ${VAR}, or ${VAR:-fallback}. */
 export declare class Variable {
     readonly name: string;
     readonly fallbackType: null | ":-" | ":=";
-    readonly fallback: any;
-    constructor(name: string, fallbackType?: null | ":-" | ":=", fallback?: any);
+    readonly fallback: null | Token | ReadonlyArray<Token>;
+    constructor(name: string, fallbackType?: null | ":-" | ":=", fallback?: null | Token | ReadonlyArray<Token>);
     /** Stringifies the variable into it's bash version, including fallback. */
     toString(): string;
-    [TransformChildren](transformer: (token: any) => any): Variable;
+    [TransformChildren](transformer: ITokenTransform): Variable | null;
 }

--- a/dist/tokens/VariableAssignment.d.ts
+++ b/dist/tokens/VariableAssignment.d.ts
@@ -1,13 +1,12 @@
 import { TransformChildren } from "./infrastructure";
+import { Token } from ".";
 /** A variable assignment like VAR=5, VAR="hello", or VAR=${OTHER}. */
-export declare class VariableAssignment<T = any> {
+export declare class VariableAssignment {
     readonly name: string;
-    readonly value: T;
-    constructor(name: string, value: T);
+    readonly value: Token | ReadonlyArray<Token>;
+    constructor(name: string, value: Token | ReadonlyArray<Token>);
     toString(): string;
     /** Clones this with a new value, unless the value is unchanged. */
-    withValue(newValue: T): VariableAssignment<T>;
-    /** Clones this with a new value, unless the value is unchanged. */
-    withValue<U>(newValue: U): VariableAssignment<U>;
-    [TransformChildren](transformer: (token: any) => any): VariableAssignment<any>;
+    withValue(newValue: Token | readonly Token[]): VariableAssignment;
+    [TransformChildren](transformer: (token: any) => any): VariableAssignment;
 }

--- a/dist/tokens/index.d.ts
+++ b/dist/tokens/index.d.ts
@@ -5,6 +5,13 @@ import { VerbatimString } from "./VerbatimString";
 import { Word } from "./Word";
 import { Whitespace } from "./Whitespace";
 export * from "./infrastructure";
-/** All tokens that come with this library. */
-export declare type BuiltinToken = Variable | VariableAssignment | Word | QuotedString | VerbatimString | Whitespace;
-export { Variable, VariableAssignment, QuotedString, VerbatimString, Word, Whitespace };
+export { Variable } from "./Variable";
+export { VariableAssignment } from "./VariableAssignment";
+export { QuotedString } from "./QuotedString";
+export { VerbatimString } from "./VerbatimString";
+export { Word } from "./Word";
+export { Whitespace } from "./Whitespace";
+/** Union of token types which are produced by the parser. */
+export declare type ParseToken = Variable | VariableAssignment | Word | QuotedString | VerbatimString | Whitespace;
+/** Union of token types handled by transforms. */
+export declare type Token = string | ParseToken;

--- a/dist/tokens/infrastructure/transformChildren.d.ts
+++ b/dist/tokens/infrastructure/transformChildren.d.ts
@@ -1,21 +1,19 @@
-import { TransformChildren } from "./Symbols";
-interface IHaveChildren {
-    [TransformChildren](transformer: (item: any) => any): this;
-}
+import { Token } from "..";
+/** A function for transforming a token. */
+export declare type ITokenTransform = (item: Token) => null | undefined | Token | ReadonlyArray<Token>;
 /** Transform an array, returning a new array if any children change.
  * @param value The array to transform.
  * @param transformer The function to use to transform each child. Return a nullish value to remove
  * the child, an array to replace it with multiple new items, or the original child.
  */
-export declare function transformChildren<T>(value: ReadonlyArray<T>, transformer: (item: any) => any): ReadonlyArray<T>;
-/** If the value provides support for transforming it's children, then transform them.
- * @param value The array to transform.
- * @param transformer The function to use to transform each child. Return a nullish value to remove
- * the child, an array to replace it with multiple new items, or the original child.*/
-export declare function transformChildren<T extends IHaveChildren>(value: T, transformer: (item: any) => any): T;
+export declare function transformChildren(value: ReadonlyArray<Token>, transformer: ITokenTransform): ReadonlyArray<Token>;
 /** Transform an object's children if it supports it.
- * @param value The array to transform.
+ * @param value The object which may have children to transform.
  * @param transformer The function to use to transform each child. Return a nullish value to remove
  * the child, an array to replace it with multiple new items, or the original child.*/
-export declare function transformChildren(value: any, transformer: (item: any) => any): any;
-export {};
+export declare function transformChildren(value: Token, transformer: ITokenTransform): Token;
+/** Transform an array or an object's children if it supports it.
+ * @param value The object or array which may have children to transform.
+ * @param transformer The function to use to transform each child. Return a nullish value to remove
+ * the child, an array to replace it with multiple new items, or the original child.*/
+export declare function transformChildren(value: Token | ReadonlyArray<Token>, transformer: ITokenTransform): Token | ReadonlyArray<Token>;

--- a/dist/transforms/collapseWhitespace.d.ts
+++ b/dist/transforms/collapseWhitespace.d.ts
@@ -1,3 +1,5 @@
-import { Whitespace } from "../tokens";
-export declare function collapseWhitespace(token: Whitespace): Whitespace | null;
-export declare function collapseWhitespace<T>(token: T): T;
+import { Whitespace, Token } from "../tokens";
+export declare function collapseWhitespace(token: null | Whitespace): null;
+export declare function collapseWhitespace(token: Token): Token;
+export declare function collapseWhitespace(token: readonly Token[]): readonly Token[];
+export declare function collapseWhitespace(token: null | Token | readonly Token[]): null | Token | readonly Token[];

--- a/dist/transforms/extractEnvironment.d.ts
+++ b/dist/transforms/extractEnvironment.d.ts
@@ -1,6 +1,7 @@
+import { Token } from "../tokens";
 import { Environment } from "../Environment";
 /** Assigns any variable assignment tokens into the environment. If their value has not yet been
  * substituted then the environment at that step is used. Note that the usual order for bash is to
  * first substitute all tokens up front, then assign variables. If that ordering is preferred then
  * call @see substitute() on the tree first. */
-export declare function extractEnvironment(token: any, env?: Environment): Environment;
+export declare function extractEnvironment(token: null | Token | readonly Token[], env?: Environment): Environment;

--- a/dist/transforms/stringify.d.ts
+++ b/dist/transforms/stringify.d.ts
@@ -1,4 +1,5 @@
+import { Token } from "../tokens";
 /** Converts a token to a string. Whitespace is concatenated verbatim and quoted strings are
  * expanded to their content, without the quotes. Variables which haven't been substituted are
  * stripped. */
-export declare function stringify(token: any): string;
+export declare function stringify(token: null | Token | readonly Token[]): string;

--- a/dist/transforms/substitute.d.ts
+++ b/dist/transforms/substitute.d.ts
@@ -1,3 +1,5 @@
-import { BuiltinToken } from "../tokens";
+import { Token } from "../tokens";
 import { Environment } from "../Environment";
-export declare function substitute(token: readonly BuiltinToken[], env: Environment, inlineAssignment?: boolean): BuiltinToken[];
+export declare function substitute(token: Token, env: Environment, inlineAssignment?: boolean): Token;
+export declare function substitute(token: readonly Token[], env: Environment, inlineAssignment?: boolean): readonly Token[];
+export declare function substitute(token: Token | readonly Token[], env: Environment, inlineAssignment?: boolean): Token | readonly Token[];

--- a/dist/transforms/toShellArgs.d.ts
+++ b/dist/transforms/toShellArgs.d.ts
@@ -1,9 +1,9 @@
-import { Variable, VariableAssignment } from "../tokens";
+import { Variable, VariableAssignment, Token } from "../tokens";
 /** Convert the token list into an array of strings suitable for passing to a shell process as args.
  */
-export declare function toShellArgs(token: ReadonlyArray<any>): string[];
+export declare function toShellArgs(token: ReadonlyArray<Token>): string[];
 /** Unsubstituted variables are stripped from shell args. */
 export declare function toShellArgs(token: Variable | VariableAssignment): null;
 /** Convert the token list into an array of strings suitable for passing to a shell process as args.
  */
-export declare function toShellArgs(token: any): string;
+export declare function toShellArgs(token: Token): string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Environment } from "./Environment";
 import { parse as parsePeg } from "./parser.pegjs";
 import { substitute, collapseWhitespace, stringify } from "./transforms";
-import { BuiltinToken } from "./tokens";
+import { ParseToken } from "./tokens";
 
 export * from "./tokens";
 export * from "./transforms";
@@ -13,7 +13,7 @@ export { Environment } from "./Environment";
  * "And '  quoted' spaces".
  * @returns The parse tree representing the input. */
 export const parse = (expression: string) =>
-  parsePeg(expression) as ReadonlyArray<BuiltinToken>;
+  parsePeg(expression) as ReadonlyArray<ParseToken>;
 
 /** Replaces environment variables in the input.
  * @param expression The input text. Eg: "${NODE_ENV:-${ENV:-prod}}", "My name is $NAME",
@@ -23,7 +23,7 @@ export const parse = (expression: string) =>
  * @returns A string with all environment variables either replaced, or removed if no value could be
  * substituted. Adjacent whitespace is collapsed down to a single space unless quoted. */
 export const replace = (expression: string, environment: Environment) => {
-  const parsed: ReadonlyArray<BuiltinToken> = parsePeg(expression);
+  const parsed: ReadonlyArray<ParseToken> = parsePeg(expression);
   const substituted = substitute(parsed, environment);
   const collapsed = collapseWhitespace(substituted);
   return stringify(collapsed);

--- a/src/tokens/QuotedString.ts
+++ b/src/tokens/QuotedString.ts
@@ -1,15 +1,20 @@
-import { TransformChildren, transformChildren } from "./infrastructure";
+import {
+  TransformChildren,
+  transformChildren,
+  ITokenTransform
+} from "./infrastructure";
+import { Token } from ".";
 
 /** Text quoted with double quotes: ". Variables substitution is performed in these strings and
  * whitespace is preserved, but no other characters like ' have any special meaning. */
 export class QuotedString {
-  constructor(public readonly contents: ReadonlyArray<any> | string) {}
+  constructor(public readonly contents: Token | ReadonlyArray<Token>) {}
 
   toString() {
     return `"${this.contents}"`;
   }
 
-  [TransformChildren](transformer: (item: any) => any) {
+  [TransformChildren](transformer: ITokenTransform) {
     const contents = this.contents;
     const transformed = transformChildren(contents, transformer);
     return transformed !== contents ? new QuotedString(transformed) : this;

--- a/src/tokens/Variable.ts
+++ b/src/tokens/Variable.ts
@@ -1,11 +1,16 @@
-import { transformChildren, TransformChildren } from "./infrastructure";
+import {
+  transformChildren,
+  TransformChildren,
+  ITokenTransform
+} from "./infrastructure";
+import { Token } from ".";
 
 /** A variable reference like $VAR, ${VAR}, or ${VAR:-fallback}. */
 export class Variable {
   constructor(
     public readonly name: string,
     public readonly fallbackType: null | ":-" | ":=" = null,
-    public readonly fallback: any = null
+    public readonly fallback: null | Token | ReadonlyArray<Token> = null
   ) {}
 
   /** Stringifies the variable into it's bash version, including fallback. */
@@ -15,8 +20,9 @@ export class Variable {
     );
   }
 
-  [TransformChildren](transformer: (token: any) => any) {
+  [TransformChildren](transformer: ITokenTransform) {
     const contents = this.fallback;
+    if (contents == null) return contents;
     const transformed = transformChildren(contents, transformer);
     return transformed !== contents
       ? new Variable(this.name, this.fallbackType, transformed)

--- a/src/tokens/VariableAssignment.ts
+++ b/src/tokens/VariableAssignment.ts
@@ -1,18 +1,19 @@
 import { TransformChildren, transformChildren } from "./infrastructure";
+import { Token } from ".";
 
 /** A variable assignment like VAR=5, VAR="hello", or VAR=${OTHER}. */
-export class VariableAssignment<T = any> {
-  constructor(public readonly name: string, public readonly value: T) {}
+export class VariableAssignment {
+  constructor(
+    public readonly name: string,
+    public readonly value: Token | ReadonlyArray<Token>
+  ) {}
 
   toString() {
     return this.name + "=" + this.value;
   }
 
   /** Clones this with a new value, unless the value is unchanged. */
-  withValue(newValue: T): VariableAssignment<T>;
-  /** Clones this with a new value, unless the value is unchanged. */
-  withValue<U>(newValue: U): VariableAssignment<U>;
-  withValue(newValue: any) {
+  withValue(newValue: Token | readonly Token[]) {
     return this.value === newValue
       ? this
       : new VariableAssignment(this.name, newValue);

--- a/src/tokens/Whitespace.ts
+++ b/src/tokens/Whitespace.ts
@@ -4,6 +4,6 @@ export class Whitespace {
   constructor(public readonly contents: string) {}
 
   toString() {
-    return `(${this.contents})`;
+    return `${this.contents}`;
   }
 }

--- a/src/tokens/Word.ts
+++ b/src/tokens/Word.ts
@@ -3,6 +3,6 @@ export class Word {
   constructor(public readonly contents: string) {}
 
   toString() {
-    return `(${this.contents})`;
+    return `${this.contents}`;
   }
 }

--- a/src/tokens/index.ts
+++ b/src/tokens/index.ts
@@ -4,10 +4,17 @@ import { QuotedString } from "./QuotedString";
 import { VerbatimString } from "./VerbatimString";
 import { Word } from "./Word";
 import { Whitespace } from "./Whitespace";
-export * from "./infrastructure";
 
-/** All tokens that come with this library. */
-export type BuiltinToken =
+export * from "./infrastructure";
+export { Variable } from "./Variable";
+export { VariableAssignment } from "./VariableAssignment";
+export { QuotedString } from "./QuotedString";
+export { VerbatimString } from "./VerbatimString";
+export { Word } from "./Word";
+export { Whitespace } from "./Whitespace";
+
+/** Union of token types which are produced by the parser. */
+export type ParseToken =
   | Variable
   | VariableAssignment
   | Word
@@ -15,11 +22,5 @@ export type BuiltinToken =
   | VerbatimString
   | Whitespace;
 
-export {
-  Variable,
-  VariableAssignment,
-  QuotedString,
-  VerbatimString,
-  Word,
-  Whitespace
-};
+/** Union of token types handled by transforms. */
+export type Token = string | ParseToken;

--- a/src/transforms/collapseWhitespace.ts
+++ b/src/transforms/collapseWhitespace.ts
@@ -1,29 +1,34 @@
-import { Whitespace, transformChildren } from "../tokens";
+import { Whitespace, Token, transformChildren } from "../tokens";
 
-export function collapseWhitespace(token: Whitespace): Whitespace | null;
-export function collapseWhitespace<T>(token: T): T;
+export function collapseWhitespace(token: null | Whitespace): null;
+export function collapseWhitespace(token: Token): Token;
+export function collapseWhitespace(token: readonly Token[]): readonly Token[];
+export function collapseWhitespace(
+  token: null | Token | readonly Token[]
+): null | Token | readonly Token[];
 
-/** Collapses adjacent whitespace down to a single space. Substituted variables which have no value
- * are removed, and whitespace around them is considered adjacent.
- * @param token The token to process. */
-export function collapseWhitespace(token: any): any {
-  if (Array.isArray(token)) {
-    let lastWasWs = false;
-    let hasOutput = false;
-    return transformChildren(token, child => {
-      if (child instanceof Whitespace) {
-        lastWasWs = true;
-        return;
-      }
-
-      const next = collapseWhitespace(child);
-      if (next == null) return;
-      const prefixWs = lastWasWs && hasOutput;
-      lastWasWs = false;
-      hasOutput = true;
-      return prefixWs ? [new Whitespace(" "), next] : next;
-    });
+/** Collapses adjacent whitespace down to a single space. Only collapses a single level, without
+ * recursing into children.
+ * @param token The token or array of tokens to process. */
+export function collapseWhitespace(
+  token: null | Token | readonly Token[]
+): null | Token | readonly Token[] {
+  if (token == null) return null;
+  if (!Array.isArray(token)) {
+    return token instanceof Whitespace ? null : token;
   }
 
-  return token;
+  let lastWasWs = false;
+  let hasOutput = false;
+  return transformChildren(token, child => {
+    if (child instanceof Whitespace) {
+      lastWasWs = true;
+      return null;
+    }
+
+    const prefixWs = lastWasWs && hasOutput;
+    lastWasWs = false;
+    hasOutput = true;
+    return prefixWs ? [new Whitespace(" "), child] : child;
+  });
 }

--- a/src/transforms/extractEnvironment.ts
+++ b/src/transforms/extractEnvironment.ts
@@ -1,4 +1,4 @@
-import { VariableAssignment, transformChildren } from "../tokens";
+import { VariableAssignment, transformChildren, Token } from "../tokens";
 import { Environment } from "../Environment";
 import { stringify } from "./stringify";
 import { collapseWhitespace } from "./collapseWhitespace";
@@ -9,10 +9,15 @@ import { substitute } from "./substitute";
  * first substitute all tokens up front, then assign variables. If that ordering is preferred then
  * call @see substitute() on the tree first. */
 export function extractEnvironment(
-  token: any,
+  token: null | Token | readonly Token[],
   env: Environment = {}
 ): Environment {
-  function extract(t: any) {
+  if (token != null) {
+    extract(token);
+  }
+  return env;
+
+  function extract(t: Token | readonly Token[]) {
     if (t instanceof VariableAssignment) {
       const substitutedValue = substitute(t.value, env, false);
       const collapsedValue = collapseWhitespace(substitutedValue);
@@ -25,7 +30,4 @@ export function extractEnvironment(
     }
     return t;
   }
-
-  extract(token);
-  return env;
 }

--- a/src/transforms/filter.ts
+++ b/src/transforms/filter.ts
@@ -1,13 +1,16 @@
-import { transformChildren } from "../tokens";
+import { transformChildren, Token } from "../tokens";
 
 /** Returns a new tree with any matching tokens removed. */
-export function filter<T>(
-  token: T,
-  shouldRemove: (token: any) => boolean
-): T | null {
-  function strip(t: any) {
+export function filter(
+  token: Token | readonly Token[],
+  shouldRemove: (token: Token) => boolean
+): Token | readonly Token[] {
+  return Array.isArray(token)
+    ? transformChildren(token, strip)
+    : strip(token as Token);
+
+  function strip(t: Token) {
     if (shouldRemove(t)) return null;
     return transformChildren(t, strip);
   }
-  return strip(token);
 }

--- a/src/transforms/some.ts
+++ b/src/transforms/some.ts
@@ -1,11 +1,22 @@
-import { transformChildren } from "../tokens";
+import { transformChildren, Token } from "../tokens";
 
 /** Returns whether the token or any children match a test function. */
-export function some<T>(token: T, test: (token: any) => boolean): T | null {
+export function some(
+  token: Token | readonly Token[],
+  isMatch: (token: Token | readonly Token[]) => boolean
+): boolean {
   let found = false;
-  function doSome(t: any) {
-    if (found || (found = test(t))) return t;
+
+  if (Array.isArray(token)) {
+    transformChildren(token, doSome);
+  } else {
+    doSome(token as Token);
+  }
+
+  return found;
+
+  function doSome(t: Token) {
+    if (found || (found = isMatch(t))) return t;
     return transformChildren(t, doSome);
   }
-  return doSome(token);
 }

--- a/src/transforms/stringify.ts
+++ b/src/transforms/stringify.ts
@@ -4,17 +4,20 @@ import {
   VerbatimString,
   Word,
   transformChildren,
-  VariableAssignment
+  VariableAssignment,
+  Token
 } from "../tokens";
 
 /** Converts a token to a string. Whitespace is concatenated verbatim and quoted strings are
  * expanded to their content, without the quotes. Variables which haven't been substituted are
  * stripped. */
-export function stringify(token: any): string {
+export function stringify(token: null | Token | readonly Token[]): string {
   return str(token) ?? "";
 }
 
-function str(token: any): string | null | undefined {
+function str(
+  token: null | Token | readonly Token[]
+): string | null | undefined {
   if (typeof token === "string") return token;
 
   if (Array.isArray(token)) {
@@ -29,9 +32,10 @@ function str(token: any): string | null | undefined {
     const contents = token.contents ?? "";
     if (typeof contents === "string") return contents;
     let result = "";
-    for (const item of contents) {
+    transformChildren(contents, item => {
       result += str(item) ?? "";
-    }
+      return item;
+    });
     return result;
   }
 

--- a/src/transforms/substitute.ts
+++ b/src/transforms/substitute.ts
@@ -45,7 +45,7 @@ export function substitute(
   env: Environment,
   inlineAssignment: boolean = false
 ) {
-  return transformChildren(token, sub);
+  return sub(token);
 
   function sub(
     token: Token | ReadonlyArray<Token>

--- a/src/transforms/substitute.ts
+++ b/src/transforms/substitute.ts
@@ -4,8 +4,7 @@ import {
   transformChildren,
   Whitespace,
   Word,
-  BuiltinToken,
-  VerbatimString
+  Token
 } from "../tokens";
 import { Environment } from "../Environment";
 import { collapseWhitespace } from "./collapseWhitespace";
@@ -17,10 +16,22 @@ const parseEnvValue = (value: string) =>
   parsePeg(value, parseOptions) as Array<Whitespace | Word>;
 
 export function substitute(
-  token: readonly BuiltinToken[],
+  token: Token,
   env: Environment,
   inlineAssignment?: boolean
-): BuiltinToken[];
+): Token;
+
+export function substitute(
+  token: readonly Token[],
+  env: Environment,
+  inlineAssignment?: boolean
+): readonly Token[];
+
+export function substitute(
+  token: Token | readonly Token[],
+  env: Environment,
+  inlineAssignment?: boolean
+): Token | readonly Token[];
 
 /** Returns a new syntax tree with all variable references substituted/expanded.
  * @param token The root token to transform.
@@ -30,11 +41,15 @@ export function substitute(
  * to true to enable `cross-env` style variable assignment. If true, the tokens are removed from the
  * resulting tree once assigned. */
 export function substitute(
-  token: any,
+  token: Token | readonly Token[],
   env: Environment,
   inlineAssignment: boolean = false
 ) {
-  function sub(token: any): any {
+  return transformChildren(token, sub);
+
+  function sub(
+    token: Token | ReadonlyArray<Token>
+  ): null | Token | ReadonlyArray<Token> {
     if (token instanceof Variable) {
       const value = env[token.name];
       if (value == null || value === "") {
@@ -45,8 +60,10 @@ export function substitute(
 
     if (token instanceof VariableAssignment) {
       const substitutedValue = sub(token.value);
+      if (substitutedValue == null) return null;
       if (inlineAssignment) {
         const collapsedValue = collapseWhitespace(substitutedValue);
+        if (collapsedValue == null) return null;
         const stringValue = stringify(collapsedValue);
         env[token.name] = stringValue;
         return null;
@@ -56,5 +73,4 @@ export function substitute(
 
     return transformChildren(token, sub);
   }
-  return sub(token);
 }

--- a/src/transforms/toShellArgs.ts
+++ b/src/transforms/toShellArgs.ts
@@ -4,24 +4,25 @@ import {
   Word,
   Whitespace,
   VerbatimString,
-  VariableAssignment
+  VariableAssignment,
+  Token
 } from "../tokens";
 import { stringify } from "./stringify";
 
 /** Convert the token list into an array of strings suitable for passing to a shell process as args.
  */
-export function toShellArgs(token: ReadonlyArray<any>): string[];
+export function toShellArgs(token: ReadonlyArray<Token>): string[];
 /** Unsubstituted variables are stripped from shell args. */
 export function toShellArgs(token: Variable | VariableAssignment): null;
 /** Convert the token list into an array of strings suitable for passing to a shell process as args.
  */
-export function toShellArgs(token: any): string;
+export function toShellArgs(token: Token): string;
 
-export function toShellArgs(token: any) {
+export function toShellArgs(token: Token | ReadonlyArray<Token>) {
   if (Array.isArray(token)) {
     const args: string[] = [];
     let lastWasWs = false;
-    for (const child of token) {
+    for (const child of token as Token[]) {
       if (child instanceof Whitespace) {
         lastWasWs = true;
       } else {

--- a/test/transforms/collapseWhitespace.test.js
+++ b/test/transforms/collapseWhitespace.test.js
@@ -1,0 +1,88 @@
+const {
+  collapseWhitespace,
+  Variable: Var,
+  VariableAssignment: VarAssign,
+  Whitespace: Ws,
+  Word: W
+} = require("../../");
+
+describe("transforms.collapseWhitespace", () => {
+  it("returns null for whitespace token", () => {
+    const collapsed = collapseWhitespace(new Ws("   "));
+    expect(collapsed).toBeNull();
+  });
+
+  it("removes whitespace", () => {
+    const collapsed = collapseWhitespace([new Ws("   "), new Ws("   ")]);
+    expect(collapsed).toMatchObject([]);
+  });
+
+  it("removes leading whitespace", () => {
+    const collapsed = collapseWhitespace([
+      new Ws("   "),
+      new Ws("   "),
+      new W("a")
+    ]);
+    expect(collapsed).toMatchObject([new W("a")]);
+  });
+
+  it("removes trailing whitespace", () => {
+    const collapsed = collapseWhitespace([
+      new W("a"),
+      new Ws("   "),
+      new Ws("   ")
+    ]);
+    expect(collapsed).toMatchObject([new W("a")]);
+  });
+
+  it("collapses internal whitespace", () => {
+    const collapsed = collapseWhitespace([
+      new W("a"),
+      new Ws("   "),
+      new Ws("   "),
+      new W("b")
+    ]);
+    expect(collapsed).toMatchObject([new W("a"), new Ws(" "), new W("b")]);
+  });
+
+  it("doesn't recurse into children", () => {
+    const collapsed = collapseWhitespace([new Var("v", ":-", [new Ws("   ")])]);
+    expect(collapsed).toMatchObject([new Var("v", ":-", [new Ws("   ")])]);
+  });
+
+  it("collapses whitespace correctly around variables", () => {
+    const collapsed = collapseWhitespace([
+      new W("a"),
+      new Ws("   "),
+      new Var("v"),
+      new Ws("   "),
+      new W("b")
+    ]);
+    expect(collapsed).toMatchObject([
+      new W("a"),
+      new Ws(" "),
+      new Var("v"),
+      new Ws(" "),
+      new W("b")
+    ]);
+  });
+
+  it("strings count as tokens", () => {
+    const collapsed = collapseWhitespace([
+      new Ws("   "),
+      "a",
+      new Ws("   "),
+      new Var("v"),
+      new Ws("   "),
+      "d",
+      new Ws("   ")
+    ]);
+    expect(collapsed).toMatchObject([
+      "a",
+      new Ws(" "),
+      new Var("v"),
+      new Ws(" "),
+      "d"
+    ]);
+  });
+});


### PR DESCRIPTION
During earlier refactoring, the types started to become quite unweildy due to some overengineering. I'm working to remove that mistake, and move back to proper strict typing.